### PR TITLE
Potential fix for code scanning alert no. 23: Uncontrolled data used in path expression

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -25,7 +25,20 @@ import { rateLimit } from 'express-rate-limit';
 import path from 'path';
 
 const app = express();
-const upload = multer({ dest: '/tmp/' });
+const upload = multer({
+  storage: multer.diskStorage({
+    destination: (req, file, cb) => {
+      // Ensure uploads are stored under the configured uploads directory
+      const uploadDir = path.join(uploadsPath, uploadsRelativePath);
+      cb(null, uploadDir);
+    },
+    filename: (req, file, cb) => {
+      // Use a server-generated filename to avoid using any user-controlled path parts
+      const generatedName = uuidv4() + '.jpg';
+      cb(null, generatedName);
+    },
+  }),
+});
 
 const uploadImageRateLimiter = rateLimit({
   windowMs: 10 * 60 * 1000, // 10 minutes


### PR DESCRIPTION
Potential fix for [https://github.com/192kb/levsha-backend/security/code-scanning/23](https://github.com/192kb/levsha-backend/security/code-scanning/23)

In general, to fix this class of issue you want to ensure that any filesystem path that ultimately depends on user input is (a) constrained to a specific safe directory, (b) not directly influenced by raw user data such as filenames or path components, and (c) validated/normalized before being passed to filesystem APIs. When using Multer, this typically means using a disk storage configuration that writes to a known-safe base directory and generates server-side filenames, and then only using those controlled paths in subsequent operations like `fs.rename`.

For this specific code, the main improvement is to align Multer’s initial upload directory with the already configured `uploadsPath`/`uploadsRelativePath` area, and ensure that the filepath Multer produces remains fully under our control. Instead of using the simple `multer({ dest: '/tmp/' })` constructor, we can switch to `multer.diskStorage` and set a fixed upload directory (for example, `path.join(uploadsPath, uploadsRelativePath)`) and a generated filename (e.g., a UUID with `.tmp` or `.jpg`). This guarantees that the initial file path (`req.file.path`) is always under the intended upload directory and does not contain user-controlled path components. We will continue to generate our own final filename (`uuidv4() + '.jpg'`) and will keep using `path.normalize` combined with known-safe configuration values when renaming. All of this happens inside `server.ts`, so the changes are localized to the Multer configuration (around line 28) without altering the observable behavior of `/task/image`: clients still upload via the `taskImage` field, and the response JSON structure remains the same.

Concretely:
- Replace `const upload = multer({ dest: '/tmp/' });` with a `multer.diskStorage` configuration that:
  - Uses `path.join(uploadsPath, uploadsRelativePath)` as the upload directory.
  - Generates a server-side filename via `uuidv4()` plus a fixed extension (e.g. `.tmp` or `.jpg`).
- Keep the rest of the `/task/image` handler unchanged, so we still rename from `req.file.path` to `uploadsPath + uploadsRelativePath + fileName` and persist the URL as before.
- No new imports are required because `path` and `uuidv4` are already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
