### PR TITLE
Potential fix for code scanning alert no. 23: Uncontrolled data used in path expression

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -25,12 +25,12 @@ import { rateLimit } from 'express-rate-limit';
 import path from 'path';
 
 const app = express();
+const uploadRoot = path.join(uploadsPath, uploadsRelativePath);
 const upload = multer({
   storage: multer.diskStorage({
     destination: (req, file, cb) => {
       // Ensure uploads are stored under the configured uploads directory
-      const uploadDir = path.join(uploadsPath, uploadsRelativePath);
-      cb(null, uploadDir);
+      cb(null, uploadRoot);
     },
     filename: (req, file, cb) => {
       // Use a server-generated filename to avoid using any user-controlled path parts
@@ -549,7 +549,7 @@ app.post(
     req.file &&
       fs.rename(
         req.file.path,
-        path.normalize(uploadsPath + uploadsRelativePath + fileName),
+        path.join(uploadRoot, fileName),
         (err) => {
           if (err) {
             res.status(500).send(err);


### PR DESCRIPTION
Potential fix for [https://github.com/192kb/levsha-backend/security/code-scanning/23](https://github.com/192kb/levsha-backend/security/code-scanning/23)

In general, the fix is to construct filesystem paths in a way that (a) does not mix raw concatenation of path strings, and (b) explicitly anchors all per‑request paths under a trusted root directory. This is typically done by defining a canonical upload root directory once, then building all derived paths using `path.join` (which handles separators correctly) and optionally checking that normalized paths remain under that root.

For this specific code, the only path sensitive operation in the shown snippet is the destination path in `fs.rename` inside the `/task/image` route. We can fix it by:

1. Defining a constant upload root directory using the already imported `path` module, e.g. `const uploadRoot = path.join(uploadsPath, uploadsRelativePath);` near the top of the file (after imports or after `const app = express();`), so it is computed once.
2. Updating the Multer `destination` option to use that `uploadRoot` instead of recomputing `path.join(uploadsPath, uploadsRelativePath)` inline; this keeps behavior the same and centralizes the path logic.
3. Replacing the current `fs.rename` destination `path.normalize(uploadsPath + uploadsRelativePath + fileName)` with `path.join(uploadRoot, fileName)`. This avoids manual string concatenation, uses the same trusted base path as Multer’s destination, and leverages the platform‑correct joining behavior.
4. We do not need new imports: `path` and `fs` are already imported.

We avoid changing any observable behavior: files are still stored under the same directory and with the same generated filename; only the way the path is composed is changed to be safer and clearer.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
