### PR TITLE
Potential fix for code scanning alert no. 4: Missing CSRF middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "path": "^0.12.7",
     "sqlstring": "^2.3.3",
     "typescript": "^5.9.3",
-    "uuid": "^13.0.0"
+    "uuid": "^13.0.0",
+    "lusca": "^1.7.0"
   },
   "scripts": {
     "start": "ts-node server.ts"

--- a/server.ts
+++ b/server.ts
@@ -23,6 +23,7 @@ import session from 'express-session';
 import { sessionSecret } from './credentials/salt';
 import { rateLimit } from 'express-rate-limit';
 import path from 'path';
+import lusca from 'lusca';
 
 const app = express();
 const uploadRoot = path.join(uploadsPath, uploadsRelativePath);
@@ -39,6 +40,11 @@ const upload = multer({
     },
   }),
 });
+
+// Apply CSRF protection for all routes that rely on cookie-based authentication.
+// This should be registered after cookieParser/session setup (configured elsewhere
+// in this file) and before any state-changing route handlers.
+app.use(lusca.csrf());
 
 const uploadImageRateLimiter = rateLimit({
   windowMs: 10 * 60 * 1000, // 10 minutes


### PR DESCRIPTION
Potential fix for [https://github.com/192kb/levsha-backend/security/code-scanning/4](https://github.com/192kb/levsha-backend/security/code-scanning/4)

In general, to fix missing CSRF protection in an Express app that uses cookie-based sessions, you add a CSRF middleware (such as `lusca.csrf` or `csurf`) after `cookieParser` and `session` are configured, and then ensure that all state-changing routes either (a) are protected by the middleware and enforce a valid token, or (b) are explicitly opted out (e.g., pure API endpoints using non-cookie auth). The middleware issues a per-session token which the frontend must send back (e.g., in a header or form field) with each mutating request.

For this codebase, the least invasive, single best fix is:
- Import `csrf` from `lusca`.
- Apply `app.use(csrf())` globally after any session/cookie setup (we don’t see that part of `server.ts`, but it’s clearly using `express-session` and `cookie-parser` from the imports, so we place the middleware near the top, shortly after we create `app` and before defining the handlers).
- Optionally, expose a small helper endpoint to return the current CSRF token for clients that need to read it (for SPAs or mobile apps that still use cookies), using `req.csrfToken()` which `lusca` provides.

Because the snippet doesn’t show the existing `session` and `cookieParser` setup calls, we avoid editing them and only add:
- A `lusca` import at the top.
- A new `app.use(lusca.csrf())` (or destructured `const { csrf } = lusca; app.use(csrf());`) before the handlers. This protects all affected routes, including those CodeQL links point to, without changing their business logic.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
