### PR TITLE
Potential fix for code scanning alert no. 35: Uncontrolled data used in path expression

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1004,8 +1004,14 @@ app.post(
       return res.status(400).send({ message: 'Invalid upload path' });
     }
 
+    const sourcePath = path.resolve(req.file.path);
+    const tempUploadRoot = path.resolve(uploadRoot);
+    if (!(sourcePath === tempUploadRoot || sourcePath.startsWith(tempUploadRoot + path.sep))) {
+      return res.status(400).send({ message: 'Invalid source upload path' });
+    }
+
     fs.rename(
-      req.file.path,
+      sourcePath,
       targetPath,
       (err) => {
         if (err) {


### PR DESCRIPTION
Potential fix for [https://github.com/192kb/levsha-backend/security/code-scanning/35](https://github.com/192kb/levsha-backend/security/code-scanning/35)

In general, the problem is that the code uses `req.file.path` (which depends on user input through the upload mechanism) directly as the source path in `fs.rename`. While the destination `targetPath` is validated to be under a safe root, the source path is not checked. To fix this, we should avoid trusting an arbitrary path for the source file and instead ensure that the temporary upload directory is server-controlled and that `fs.rename` (or `fs.copyFile`) is only invoked on paths under that directory.

The best targeted fix, without changing the external behavior, is to validate `req.file.path` against a known, server-controlled upload root. We can compute a safe temporary upload root (for example, using the already existing `uploadRoot` that is derived from `uploadsPath` and `uploadsRelativePath`, or a resolved version of it), normalize `req.file.path` with `path.resolve`, and then verify that this normalized source path lies within that root (similar to what is already done for `targetPath`). If the check fails, we reject the request. This limits `fs.rename` to moving files only from within our controlled upload directory to our validated destination directory.

Concretely in `server.ts` around lines 988–1035, we will:
- Introduce a `const sourcePath = path.resolve(req.file.path);`.
- Introduce a server-side `const tempUploadRoot = path.resolve(uploadRoot);` (or, if we want to ensure consistency, derive both source and destination roots from the same constant).
- Add a check that `sourcePath` is either exactly `tempUploadRoot` or starts with `tempUploadRoot + path.sep`. If it does not, return a 400 (or 403) error.
- Use `sourcePath` instead of `req.file.path` in `fs.rename`.

This does not change the user-visible semantics when uploads are normal but protects against any manipulation of the temporary upload path. No new methods or imports are needed; `path` and `fs` are already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
