### PR TITLE
Potential fix for code scanning alert no. 37: Uncontrolled data used in path expression

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -1005,7 +1005,7 @@ app.post(
     }
 
     const sourcePath = path.resolve(req.file.path);
-    const tempUploadRoot = path.resolve(uploadRoot);
+    const tempUploadRoot = path.resolve(uploadsPath);
     if (!(sourcePath === tempUploadRoot || sourcePath.startsWith(tempUploadRoot + path.sep))) {
       return res.status(400).send({ message: 'Invalid source upload path' });
     }


### PR DESCRIPTION
Potential fix for [https://github.com/192kb/levsha-backend/security/code-scanning/37](https://github.com/192kb/levsha-backend/security/code-scanning/37)

General approach: Ensure that any path derived from `req.file.path` is constrained to a known, server-controlled upload directory. Normalize the path, compare it against a trusted root directory using strict prefix checks (with separators), and reject the operation if the path lies outside that root. Do not rely on implicit assumptions about where multer stores files.

Concrete fix for this code: instead of deriving `tempUploadRoot` from `uploadRoot` (which is the *final* uploads directory used for user images), we should validate `sourcePath` against the actual directory where multer writes uploaded files. We already have `uploadsPath` imported; given the snippet, `uploadsPath` is used as the base for uploads and is a safer assumption for the temporary storage root than `uploadRoot` (which includes `uploadsRelativePath` for final destinations). We can therefore:

1. Compute a normalized, absolute `sourcePath` from `req.file.path` using `path.resolve` (already done).
2. Define a trusted root for temporary uploads (e.g., `const tempUploadRoot = path.resolve(uploadsPath);`).
3. Check that `sourcePath` is either exactly `tempUploadRoot` or starts with `tempUploadRoot + path.sep`. If not, reject the request with a 400 error.
4. Leave the `targetPath` validation as-is, since it already normalizes and ensures the final path stays under `uploadRoot`.

This change keeps existing behavior (move from the temp upload area into the final upload directory and update the DB) but correctly verifies that `sourcePath` lies under a trusted directory. It only adjusts one line (the computation of `tempUploadRoot`) within `server.ts`, in the `app.post(basePath + 'user/:uuid/image', ...)` handler around line 1008.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
